### PR TITLE
Accept a proc, symbol or string for default schedule

### DIFF
--- a/lib/schedule_attributes/active_record.rb
+++ b/lib/schedule_attributes/active_record.rb
@@ -7,9 +7,16 @@ module ScheduleAttributes::ActiveRecord
 
   module ClassMethods
     attr_accessor :schedule_field
-    attr_accessor :default_schedule
+    attr_writer   :default_schedule
 
     def default_schedule
+      @default_schedule = case @default_schedule
+      when Proc
+        @default_schedule.call
+      when Symbol, String
+        self.public_send(@default_schedule)
+      end if @default_schedule
+
       @default_schedule || ScheduleAttributes.default_schedule
     end
   end

--- a/spec/active_record_integration_spec.rb
+++ b/spec/active_record_integration_spec.rb
@@ -16,6 +16,20 @@ describe CustomScheduledActiveRecordModel do
 
 end
 
+describe CustomScheduledMethodActiveRecordModel do
+
+  it "should have a default schedule" do
+    subject.schedule.should == today
+  end
+
+  def today
+    IceCube::Schedule.new(Date.today.to_time).tap { |s|
+      s.add_recurrence_rule IceCube::SingleOccurrenceRule.new(Date.today)
+    }
+  end
+
+end
+
 describe DefaultScheduledActiveRecordModel do
   alias :model :subject
 

--- a/spec/support/scheduled_active_record_model.rb
+++ b/spec/support/scheduled_active_record_model.rb
@@ -31,6 +31,17 @@ class CustomScheduledActiveRecordModel < ActiveRecord::Base
   end
 end
 
+class CustomScheduledMethodActiveRecordModel < ActiveRecord::Base
+  self.table_name = :calendars
+  has_schedule_attributes default_schedule: :today
+
+  def self.today
+    s = IceCube::Schedule.new(Date.today.to_time)
+    s.add_recurrence_rule IceCube::SingleOccurrenceRule.new(Date.today)
+    s
+  end
+end
+
 class DefaultScheduledActiveRecordModel < ActiveRecord::Base
   self.table_name = :calendars
   has_schedule_attributes


### PR DESCRIPTION
Allow proc, symbol or string for setting default schedule in `has_schedule_attributes` class method.